### PR TITLE
chore(ddo): removing redundant carbon prefix for DDO

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The template has a placeholder DDO you can define located in `pages/data/DDO.jso
             language: '', // e.g. en-US
             publishDate: '', // e.g. 2014-11-19
             publisher: '', // e.g. IBM Corporation
-            version: 'Carbon:Carbon for IBM.com',
+            version: 'Carbon for IBM.com',
             ibm: {
                 contentDelivery: '', // e.g. ECM/Filegen
                 contentProducer: '', // e.g. ECM/IConS Adopter 34 - GS83J2343G3H3ERG - 11/19/2014 05:14:02 PM

--- a/pages/data/DDO.json
+++ b/pages/data/DDO.json
@@ -9,7 +9,7 @@
       "language": "",
       "publishDate": "",
       "publisher": "",
-      "version": "Carbon:Carbon for IBM.com",
+      "version": "Carbon for IBM.com",
       "ibm": {
         "contentDelivery": "",
         "contentProducer": "",


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

After renaming to `Carbon for IBM.com`, our version was renamed but
retained the `Carbon:` prefix as it was originally `Carbon:IBM.com
Library`. Now that we have Carbon in the name, it is a bit redundant to
have the prefix now.

### Changelog

**Changed**

- DDO documentation