### PR TITLE
fix(stylelint): turning off max-nesting-depth rule

### DIFF
--- a/packages/stylelint-config-ibmdotcom/rules/limit-language-features.js
+++ b/packages/stylelint-config-ibmdotcom/rules/limit-language-features.js
@@ -165,12 +165,7 @@ module.exports = {
 
     // General / Sheet
     // Limit the depth of nesting.
-    "max-nesting-depth": [
-      0,
-      {
-        ignoreAtRules: ["if", "else", "each", "include", "mixin"],
-      },
-    ],
+    "max-nesting-depth": OFF,
     // Disallow unknown animations.
     "no-unknown-animations": true,
   },


### PR DESCRIPTION
### Description

Not sure why this rule was there but I believe it shouldn't, as nesting is a common practice while using SASS.

### Changelog

**Changed**

- `max-nesting-depth` from 0 to `OFF`.