### PR TITLE
fix(runtime-error): ensure ibm-common script loads only once

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -87,8 +87,9 @@ export default class CarbonForIBMDotcom extends App {
               }}
             />
           )}
-
-          <script src="//1.www.s81c.com/common/stats/ibm-common.js" defer />
+          {process.browser && (
+            <script src="//1.www.s81c.com/common/stats/ibm-common.js" defer />
+          )}
         </Head>
         <DotcomShell
           mastheadProps={{


### PR DESCRIPTION
### Related Ticket(s)
#37 

### Description
There is currently a runtime error that happens due to a NextJS bug where scripts with `defer` or `async` happen to load twice. This fix ensures that the `ibm-common.js` script only loads once into the page.

### Changelog

**Changed**

- added `process.browser` to ensure the script only loads once when the page is being rendered client side

