### PR TITLE
Prevents breaking changes with node-fetch 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "resolutions": {
     "dot-prop": ">=5.1.1",
-    "node-fetch": ">=2.6.1",
+    "node-fetch": "^2.6.1",
     "object-path": ">=0.11.5",
     "serialize-javascript": ">= 3.1.0"
   }


### PR DESCRIPTION
fix: installing node-fetch 3.0.0 as a child dependency throws an error `(node:2006) UnhandledPromiseRejectionWarning: Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /[PROJECT-PATH]/node_modules/node-fetch/src/index.js`


### Description

Running `yarn install` and then `yarn build` throws the following error:

```
(node:2006) UnhandledPromiseRejectionWarning: Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: node_modules/node-fetch/src/index.js
require() of ES modules is not supported.
require() of node_modules/node-fetch/src/index.js from node_modules/next/dist/next-server/server/node-polyfill-fetch.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
```

### Changelog

**Changed**

Changed "resolutions" in `package.json` to limit child dependency `node-fetch` to minor versions. 
